### PR TITLE
优化Mac/Linux上的运行脚本，兼容fish shell

### DIFF
--- a/install.sc
+++ b/install.sc
@@ -1,6 +1,6 @@
 ;;; Info Begin
 
-(define install-version "0.2.0")
+(define install-version "0.2.1")
 
 (define windows? 
   (case (machine-type)
@@ -83,7 +83,7 @@
               (delete-file (format "~a/raven.tar.gz" target-path)))
           (begin
             (delete-file "/usr/local/bin/raven")
-            (system "ln -s /usr/local/lib/raven/raven/raven.sc /usr/local/bin/raven")
+            (system "ln -s /usr/local/lib/raven/raven/raven.sh /usr/local/bin/raven")
             (system "chmod +x /usr/local/bin/raven")
             (printf "install raven ~a success\n" ver))
           (printf "install raven ~a fail\n" ver)

--- a/raven.sc
+++ b/raven.sc
@@ -1,6 +1,3 @@
-":"; export CHEZSCHEMELIBDIRS=.:lib:/usr/local/lib && export CHEZSCHEMELIBEXTS=.chezscheme.sls::.chezscheme.so:.ss::.so:.sls::.so:.scm::.so:.sch::.so:.sc::.so && exec scheme --script $0 "$@";
-
-
 ;;; Association List Begin
 
 (define package-sc->scm

--- a/raven.sh
+++ b/raven.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+scheme --libdirs ".:lib:/usr/local/lib" --libexts ".chezscheme.sls::.chezscheme.so:.ss::.so:.sls::.so:.scm::.so:.sch::.so:.sc::.so" --script ./raven.sc


### PR DESCRIPTION
在fish shell中执行raven命令时会报出下面的错误，需要在raven.sc的头部指定`#!/bin/bash`才行，为此优化了下运行脚本，新增了一个raven.sh文件，同时也更新了下安装脚本。
```
Failed to execute process '/usr/local/bin/raven'. Reason:
exec: Exec format error
The file '/usr/local/bin/raven' is marked as an executable but could not be run by the operating system.
```
另外注意发布时还需要同步更新下安装文档说明。